### PR TITLE
Upgraded node version to 8.16.0 and npm to 6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/rivethead42/hello-node#readme",
   "engines": {
-    "node": "8.9.4",
-    "npm": "5.6.0"
+    "node": "8.16.0",
+    "npm": "6.4.1"
   }
 }


### PR DESCRIPTION
Upgraded node version to 8.16.0 and npm to 6.4.1. Node version 8.9.4 appears to no longer be supported by PWS causing deploying in the labs to fail.